### PR TITLE
Support Optional[int] and Optional[float]

### DIFF
--- a/dataclass2PySide6/__init__.py
+++ b/dataclass2PySide6/__init__.py
@@ -1,7 +1,8 @@
 from .version import __version__ # noqa
 
-from .datawidgets import (type2Widget, BoolCheckBox, IntLineEdit,
-    FloatLineEdit, StrLineEdit, TupleGroupBox, EnumComboBox, MISSING)
+from .datawidgets import (type2Widget, BoolCheckBox, MISSING,
+    IntLineEdit, FloatLineEdit, StrLineEdit, TupleGroupBox,
+    EnumComboBox)
 from .dataclass_widget import (DataclassWidget, StackedDataclassWidget,
     TabDataclassWidget,)
 
@@ -9,12 +10,12 @@ from .dataclass_widget import (DataclassWidget, StackedDataclassWidget,
 __all__ = [
     "type2Widget",
     "BoolCheckBox",
+    "MISSING",
     "IntLineEdit",
     "FloatLineEdit",
     "StrLineEdit",
     "TupleGroupBox",
     "EnumComboBox",
-    "MISSING",
 
     "DataclassWidget",
     "StackedDataclassWidget",

--- a/dataclass2PySide6/__init__.py
+++ b/dataclass2PySide6/__init__.py
@@ -1,8 +1,8 @@
 from .version import __version__ # noqa
 
 from .datawidgets import (type2Widget, BoolCheckBox, MISSING,
-    IntLineEdit, FloatLineEdit, StrLineEdit, TupleGroupBox,
-    EnumComboBox)
+    EmptyIntValidator, IntLineEdit, FloatLineEdit, StrLineEdit,
+    TupleGroupBox, EnumComboBox)
 from .dataclass_widget import (DataclassWidget, StackedDataclassWidget,
     TabDataclassWidget,)
 
@@ -11,6 +11,7 @@ __all__ = [
     "type2Widget",
     "BoolCheckBox",
     "MISSING",
+    "EmptyIntValidator",
     "IntLineEdit",
     "FloatLineEdit",
     "StrLineEdit",

--- a/dataclass2PySide6/__init__.py
+++ b/dataclass2PySide6/__init__.py
@@ -1,8 +1,8 @@
 from .version import __version__ # noqa
 
 from .datawidgets import (type2Widget, BoolCheckBox, MISSING,
-    EmptyIntValidator, IntLineEdit, FloatLineEdit, StrLineEdit,
-    TupleGroupBox, EnumComboBox)
+    EmptyIntValidator, IntLineEdit, EmptyFloatValidator, FloatLineEdit,
+    StrLineEdit, TupleGroupBox, EnumComboBox)
 from .dataclass_widget import (DataclassWidget, StackedDataclassWidget,
     TabDataclassWidget,)
 
@@ -13,6 +13,7 @@ __all__ = [
     "MISSING",
     "EmptyIntValidator",
     "IntLineEdit",
+    "EmptyFloatValidator",
     "FloatLineEdit",
     "StrLineEdit",
     "TupleGroupBox",

--- a/dataclass2PySide6/__init__.py
+++ b/dataclass2PySide6/__init__.py
@@ -1,7 +1,7 @@
 from .version import __version__ # noqa
 
 from .datawidgets import (type2Widget, BoolCheckBox, IntLineEdit,
-    FloatLineEdit, StrLineEdit, TupleGroupBox, EnumComboBox)
+    FloatLineEdit, StrLineEdit, TupleGroupBox, EnumComboBox, MISSING)
 from .dataclass_widget import (DataclassWidget, StackedDataclassWidget,
     TabDataclassWidget,)
 
@@ -14,6 +14,7 @@ __all__ = [
     "StrLineEdit",
     "TupleGroupBox",
     "EnumComboBox",
+    "MISSING",
 
     "DataclassWidget",
     "StackedDataclassWidget",

--- a/dataclass2PySide6/datawidgets.py
+++ b/dataclass2PySide6/datawidgets.py
@@ -15,7 +15,7 @@ from PySide6.QtCore import Signal, Qt
 from PySide6.QtGui import QValidator, QIntValidator, QDoubleValidator
 from PySide6.QtWidgets import (QWidget, QCheckBox, QLineEdit, QComboBox,
     QGroupBox, QHBoxLayout)
-from typing import List, Optional, Union
+from typing import List, Union
 
 
 __all__ = [
@@ -24,6 +24,7 @@ __all__ = [
     "MISSING",
     "EmptyIntValidator",
     "IntLineEdit",
+    "EmptyFloatValidator",
     "FloatLineEdit",
     "StrLineEdit",
     "TupleGroupBox",
@@ -195,7 +196,6 @@ class IntLineEdit(QLineEdit):
         self._int_validator = QIntValidator(self)
         self._emptyint_validator = EmptyIntValidator(self)
 
-
         self.setValidator(self._int_validator)
         self.setDefaultDataValue(MISSING)
 
@@ -274,7 +274,7 @@ class IntLineEdit(QLineEdit):
         """
         return self.defaultDataValue() is not MISSING
 
-    def dataValue(self) -> int:
+    def dataValue(self) -> object:
         """
         Return the value from current text.
 
@@ -284,7 +284,7 @@ class IntLineEdit(QLineEdit):
         val = self.valueFromText(text)
         return val
 
-    def setDataValue(self, value: int):
+    def setDataValue(self, value: object):
         """
         Set current data value and update the text. If the value is
         valid, emit to :attr:`dataValueChanged`.
@@ -309,19 +309,24 @@ class IntLineEdit(QLineEdit):
             pass
 
 
+class EmptyFloatValidator(QDoubleValidator):
+    """Validator which accpets float and empty string"""
+    def validate(self, input: str, pos: int) -> QValidator.State:
+        ret = super().validate(input, pos)
+        if not input:
+            ret = QValidator.Acceptable
+        return ret
+
+
 class FloatLineEdit(QLineEdit):
     """
     Line edit for float value.
 
-    :meth:`dataValue` returns the value from current text using
-    :meth:`valueFromText`. If the text is empty, return default value
-    from :meth:defaultDataValue`.
+    :meth:`dataValue` returns the value from current text. If the text
+    is empty, return the default value if exists.
 
-    The validator is ``QDoubleValidator``. When editing is finished,
-    :attr:`dataValueChanged` signal is emitted. Because of the
-    validator, the signal is not emitted for invalid text.
-
-    :meth:`setDataValue` changes the text and emits the signal.
+    When editing is finished, :attr:`dataValueChanged` signal is
+    emitted. :meth:`setDataValue` changes the text and emits the signal.
 
     Examples
     ========
@@ -339,65 +344,125 @@ class FloatLineEdit(QLineEdit):
     ...     app.quit()
     >>> runGUI() # doctest: +SKIP
     """
-    dataValueChanged = Signal(float)
+    dataValueChanged = Signal(object)
 
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self.setValidator(QDoubleValidator())
-        self.setDefaultDataValue(None)
+        self._float_validator = QDoubleValidator(self)
+        self._emptyfloat_validator = EmptyFloatValidator(self)
+
+        self.setValidator(self._float_validator)
+        self.setDefaultDataValue(MISSING)
 
         self.editingFinished.connect(self.emitDataValueChanged)
 
     def dataName(self) -> str:
+        """
+        Name of the data field, which is displayed as placeholder text.
+        """
         return self.placeholderText()
 
     def setDataName(self, name: str):
+        """
+        Set the name of the data field. The name is displayed as
+        placeholder text and tooltip.
+        """
         self.setPlaceholderText(name)
         self.setToolTip(name)
 
-    def valueFromText(self, text: str) -> float:
+    def valueFromText(self, text: str) -> object:
         """
-        Convert the text to float value.
+        Convert the text to data value.
 
-        If the text is empty and no default value is set, raise
-        ``TypeError``.
+        If the text is not empty, convert it to ``float`` and return.
+
+        If the text is empty but the widget has default data value,
+        return the default value. If the text is empty and there is no
+        default data value, raise ``TypeError``.
+
+        See Also
+        ========
+
+        hasDefaultDataValue, defaultDataValue
+
         """
-        val = float(text) if text else self.defaultDataValue()
-        if val is None:
+        if text:
+            val = float(text)
+        elif self.hasDefaultDataValue():
+            val = self.defaultDataValue()
+        else:
             name = self.dataName() or str(self)
             raise TypeError('Missing data for %s' % name)
         return val
 
-    def defaultDataValue(self) -> Optional[float]:
+    def defaultDataValue(self) -> object:
         """
         Default value for empty text.
 
-        If line edit is empty, this value is used instead. ``None``
-        indicates no default value, where ``TypeError`` is raised for
-        missing value.
+        If line edit is empty, this value is used as data instead.
+        ``MISSING`` indicates no default value.
         """
         return self._default_data_value
 
-    def setDefaultDataValue(self, val: Optional[float]):
-        if val is None:
-            self._default_data_value = None
-        else:
-            self._default_data_value = float(val)
+    def setDefaultDataValue(self, val: object):
+        """
+        Set the default value for empty text.
 
-    def dataValue(self) -> float:
+        If ``MISSING`` is passed, it is interpreted as no default value.
+
+        If default value exists, :class:`EmptyFloatValidator` is set as
+        validator. If not, ``QDoubleValidator`` is set as validator.
+
+        """
+        self._default_data_value = val
+        if self.hasDefaultDataValue():
+            self.setValidator(self._emptyfloat_validator)
+        else:
+            self.setValidator(self._float_validator)
+
+    def hasDefaultDataValue(self) -> bool:
+        """
+        Returns whether the widget has default data value.
+
+        If :meth:`defaultDataValue` returns ``MISSING``, return
+        ``False``. Else, return ``True``.
+        """
+        return self.defaultDataValue() is not MISSING
+
+    def dataValue(self) -> object:
+        """
+        Return the value from current text.
+
+        Text is converted to value using :meth:`valueFromText`.
+        """
         text = self.text()
         val = self.valueFromText(text)
         return val
 
-    def setDataValue(self, value: float):
-        self.setText(str(value))
+    def setDataValue(self, value: object):
+        """
+        Set current data value and update the text. If the value is
+        valid, emit to :attr:`dataValueChanged`.
+
+        If the new value is same as the default value, empty str is set.
+        """
+        if value == self.defaultDataValue():
+            self.setText('')
+        else:
+            self.setText(str(value))
         self.emitDataValueChanged()
 
     def emitDataValueChanged(self):
-        text = self.text()
-        val = self.valueFromText(text)
-        self.dataValueChanged.emit(val)
+        """
+        If current :meth:`dataValue` exists, emit it to
+        :attr:`dataValueChanged`.
+        """
+        try:
+            val = self.dataValue()
+            self.dataValueChanged.emit(val)
+        except TypeError:
+            pass
 
 
 class StrLineEdit(QLineEdit):

--- a/dataclass2PySide6/datawidgets.py
+++ b/dataclass2PySide6/datawidgets.py
@@ -64,6 +64,8 @@ def type2Widget(type_or_annot) -> QWidget:
             ret = BoolCheckBox()
             ret.setTristate(True)
             return ret
+        if isinstance(arg, type) and issubclass(arg, (int, float)):
+            raise NotImplementedError
     raise TypeError('Unknown type or annotation: %s' % type_or_annot)
 
 

--- a/dataclass2PySide6/datawidgets.py
+++ b/dataclass2PySide6/datawidgets.py
@@ -64,11 +64,13 @@ def type2Widget(type_or_annot) -> QWidget:
             raise TypeError(msg)
         arg, = args
         if isinstance(arg, type) and issubclass(arg, bool):
-            ret = BoolCheckBox()
-            ret.setTristate(True)
-            return ret
+            widget = type2Widget(arg)
+            widget.setTristate(True)
+            return widget
         if isinstance(arg, type) and issubclass(arg, (int, float)):
-            raise NotImplementedError
+            widget = type2Widget(arg)
+            widget.setDefaultDataValue(None)
+            return widget
     raise TypeError('Unknown type or annotation: %s' % type_or_annot)
 
 

--- a/dataclass2PySide6/datawidgets.py
+++ b/dataclass2PySide6/datawidgets.py
@@ -26,6 +26,7 @@ __all__ = [
     "StrLineEdit",
     "TupleGroupBox",
     "EnumComboBox",
+    "MISSING",
 ]
 
 
@@ -534,3 +535,10 @@ class EnumComboBox(QComboBox):
     def emitDataValueChanged(self, index: int):
         if index != -1:
             self.dataValueChanged.emit(self.itemData(index))
+
+
+class _MISSING_TYPE:
+    """Sentinel object to detect if the default value is set or not."""
+    pass
+
+MISSING = _MISSING_TYPE()

--- a/dataclass2PySide6/datawidgets.py
+++ b/dataclass2PySide6/datawidgets.py
@@ -154,8 +154,9 @@ class IntLineEdit(QLineEdit):
     """
     Line edit for integer value.
 
-    :meth:`dataValue` returns the integer value from current text using
-    :meth:`valueFromText`.
+    :meth:`dataValue` returns the value from current text using
+    :meth:`valueFromText`. If the text is empty, return default value
+    from :meth:defaultDataValue`.
 
     The validator is ``QIntValidator``. When editing is finished,
     :attr:`dataValueChanged` signal is emitted. Because of the

--- a/dataclass2PySide6/tests/test_datawidgets.py
+++ b/dataclass2PySide6/tests/test_datawidgets.py
@@ -27,7 +27,6 @@ def test_type2Widget(qtbot):
     assert isinstance(tuplegbox2.widgets()[1].widgets()[0], IntLineEdit)
 
 
-@pytest.mark.xfail
 def test_type2Widget_Union(qtbot):
     with pytest.raises(TypeError):
         type2Widget(Union[int, float])
@@ -38,11 +37,11 @@ def test_type2Widget_Union(qtbot):
 
     optint_checkbox = type2Widget(Optional[int])
     assert isinstance(optint_checkbox, IntLineEdit)
-    assert optint_checkbox.defaultValue() is None
+    assert optint_checkbox.defaultDataValue() is None
 
     optfloat_checkbox = type2Widget(Optional[float])
     assert isinstance(optfloat_checkbox, FloatLineEdit)
-    assert optfloat_checkbox.defaultValue() is None
+    assert optfloat_checkbox.defaultDataValue() is None
 
 
 def test_BoolCheckBox(qtbot):

--- a/dataclass2PySide6/tests/test_datawidgets.py
+++ b/dataclass2PySide6/tests/test_datawidgets.py
@@ -147,14 +147,24 @@ def test_IntLineEdit(qtbot):
 def test_FloatLineEdit(qtbot):
     widget = FloatLineEdit()
 
+    assert not widget.hasDefaultDataValue()
     with pytest.raises(TypeError):
         widget.dataValue()
 
     # test default data value
     widget.setDefaultDataValue(1)
+    assert widget.hasDefaultDataValue()
     assert widget.dataValue() == float(1)
     widget.setDefaultDataValue(10)
+    assert widget.hasDefaultDataValue()
     assert widget.dataValue() == float(10)
+    widget.setDefaultDataValue(None)
+    assert widget.hasDefaultDataValue()
+    assert widget.dataValue() == None
+    widget.setDefaultDataValue(MISSING)
+    assert not widget.hasDefaultDataValue()
+    with pytest.raises(TypeError):
+        widget.dataValue()
 
     # test dataValueChanged signal
     with qtbot.waitSignal(widget.dataValueChanged,
@@ -176,6 +186,25 @@ def test_FloatLineEdit(qtbot):
         qtbot.keyPress(widget, '2')
         qtbot.keyPress(widget, Qt.Key_Return)
     assert widget.dataValue() == -1.2
+
+    # dataValueChanged signal with empty text
+    widget.clear()
+    with qtbot.assertNotEmitted(widget.dataValueChanged):
+        qtbot.keyPress(widget, Qt.Key_Return)
+    with pytest.raises(TypeError):
+        widget.dataValue()
+
+    widget.setDefaultDataValue(None)
+    with qtbot.waitSignal(widget.dataValueChanged,
+                          raising=True,
+                          check_params_cb=lambda val: val is None):
+        qtbot.keyPress(widget, Qt.Key_Return)
+
+    widget.setDefaultDataValue(float(10))
+    with qtbot.waitSignal(widget.dataValueChanged,
+                          raising=True,
+                          check_params_cb=lambda val: val == float(10)):
+        qtbot.keyPress(widget, Qt.Key_Return)
 
     # test validator
     widget.clear()

--- a/dataclass2PySide6/tests/test_datawidgets.py
+++ b/dataclass2PySide6/tests/test_datawidgets.py
@@ -27,6 +27,7 @@ def test_type2Widget(qtbot):
     assert isinstance(tuplegbox2.widgets()[1].widgets()[0], IntLineEdit)
 
 
+@pytest.mark.xfail
 def test_type2Widget_Union(qtbot):
     with pytest.raises(TypeError):
         type2Widget(Union[int, float])
@@ -34,6 +35,12 @@ def test_type2Widget_Union(qtbot):
     tristate_checkbox = type2Widget(Optional[bool])
     assert isinstance(tristate_checkbox, BoolCheckBox)
     assert tristate_checkbox.isTristate()
+
+    optint_checkbox = type2Widget(Optional[int])
+    assert isinstance(optint_checkbox, IntLineEdit)
+
+    optfloat_checkbox = type2Widget(Optional[float])
+    assert isinstance(optfloat_checkbox, FloatLineEdit)
 
 
 def test_BoolCheckBox(qtbot):

--- a/dataclass2PySide6/tests/test_datawidgets.py
+++ b/dataclass2PySide6/tests/test_datawidgets.py
@@ -2,7 +2,7 @@ from enum import Enum
 from PySide6.QtCore import Qt
 import pytest
 from dataclass2PySide6 import (type2Widget, BoolCheckBox, IntLineEdit,
-    FloatLineEdit, StrLineEdit, TupleGroupBox, EnumComboBox)
+    FloatLineEdit, StrLineEdit, TupleGroupBox, EnumComboBox, MISSING)
 from typing import Tuple, Union, Optional
 
 
@@ -83,6 +83,11 @@ def test_IntLineEdit(qtbot):
     assert widget.dataValue() == 1
     widget.setDefaultDataValue(10)
     assert widget.dataValue() == 10
+    widget.setDefaultDataValue(None)
+    assert widget.dataValue() == None
+    widget.setDefaultDataValue(MISSING)
+    with pytest.raises(TypeError):
+        widget.dataValue()
 
     # test dataValueChanged signal
     with qtbot.waitSignal(widget.dataValueChanged,


### PR DESCRIPTION
Close #29

This change breaks backwards compatibility.

- Setting default value to `None` no longer indicates missing default value.
- Default values are no longer converted to `int` or `float`.